### PR TITLE
Allow dynamically change mailer config

### DIFF
--- a/lib/bamboo/mailer.ex
+++ b/lib/bamboo/mailer.ex
@@ -64,14 +64,14 @@ defmodule Bamboo.Mailer do
     quote bind_quoted: [opts: opts] do
 
       @spec deliver_now(Bamboo.Email.t) :: Bamboo.Email.t
-      def deliver_now(email) do
-        config = build_config()
+      def deliver_now(email, opts \\ []) do
+        config = Keyword.merge(build_config(), opts)
         Bamboo.Mailer.deliver_now(config.adapter, email, config)
       end
 
       @spec deliver_later(Bamboo.Email.t) :: Bamboo.Email.t
-      def deliver_later(email) do
-        config = build_config()
+      def deliver_later(email, opts \\ []) do
+        config = Keyword.merge(build_config(), opts)
         Bamboo.Mailer.deliver_later(config.adapter, email, config)
       end
 


### PR DESCRIPTION
This adds `deliver_now/2` and `deliver_later/2` which allows user do dynamically change current mailer configuration. This is useful solution for cases when application need to dynamically change configuration (like multitenant application where user is allowed to send emails on own domain behalf).